### PR TITLE
chore: update artifact actions from v3 to v4

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -23,7 +23,7 @@ jobs:
         dry-run: false
         language: c++
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -91,7 +91,7 @@ jobs:
         python -m pytest -v --log-cli-level=INFO
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: artifacts-${{ matrix.os }}-${{ matrix.arch }}
         path: ./build/*.7z

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -100,7 +100,7 @@ jobs:
         run: cp -f dist/*.tar.gz wheelhouse/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts-${{ matrix.os }}
           path: |


### PR DESCRIPTION
Update artifact actions from v3 to v4 in all workflow files.

This PR updates the following files:
- .github/workflows/cmake.yml
- .github/workflows/cifuzz.yml
- .github/workflows/wheel.yml

These changes are required due to the upcoming deprecation:
- v3 is scheduled for deprecation on November 30, 2024
- v1/v2 are scheduled for deprecation on June 30, 2024

Link to Devin run: https://preview.devin.ai/devin/ffec4cf288b54add909b8a6366cf1a14